### PR TITLE
python-substrait v0.29.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "substrait" %}
-{% set version = "0.28.0" %}
+{% set version = "0.29.0" %}
 
 package:
   name: python-{{ name|lower }}
@@ -7,22 +7,24 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/substrait-{{ version }}.tar.gz
-  sha256: 0d73925a7fefb0503637d3dad35e70e14e74b2a72fa624ab95514ed79a067cac
+  sha256: 66a352f8b12aa97a732dd686a36fa4e5faa121cff2eae6d3cb2ceab94b544e69
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
     - pip
     - python {{ python_min }}
+    - setuptools >=61
+    - setuptools_scm >=6.2
   run:
     - protobuf >=5,<7
     - python >={{ python_min }}
-    - python-substrait-extensions ==0.79.0
-    - python-substrait-protobuf ==0.79.0
+    - python-substrait-extensions ==0.85.0
+    - python-substrait-protobuf ==0.85.0
 
 test:
   imports:


### PR DESCRIPTION
Backfill python-substrait 0.29.0 (brings the feedstock up to the latest release).

- version 0.28.0 → 0.29.0 (build number 0)
- bump pins `python-substrait-protobuf` and `python-substrait-extensions` from `==0.79.0` to `==0.85.0` (both already on the conda-forge channel)

Also addresses the linter's build-backend hint:
- declare the build backend in `host` (`setuptools`, `setuptools_scm`)
- build with `--no-deps --no-build-isolation`

🤖 Generated with AI